### PR TITLE
Script breaks on whitespace directory!!!

### DIFF
--- a/MASS-unsupNMT/src/evaluation/evaluator.py
+++ b/MASS-unsupNMT/src/evaluation/evaluator.py
@@ -570,7 +570,7 @@ def eval_moses_bleu(ref, hyp):
     assert os.path.isfile(hyp)
     assert os.path.isfile(ref) or os.path.isfile(ref + '0')
     assert os.path.isfile(BLEU_SCRIPT_PATH)
-    command = BLEU_SCRIPT_PATH + ' %s < %s'
+    command = f'"{BLEU_SCRIPT_PATH}"' + ' %s < %s'
     p = subprocess.Popen(command % (ref, hyp), stdout=subprocess.PIPE, shell=True)
     result = p.communicate()[0].decode("utf-8")
     if result.startswith('BLEU'):


### PR DESCRIPTION
Problem:: The earlier script failed to compute BLEU score while running in google colab.

Changes made:: Encapsulated the BLEU_SCRIPT_PATH into a string to handle the whitespace in a Directory.


